### PR TITLE
member election contract

### DIFF
--- a/tai/contract/Member.sol
+++ b/tai/contract/Member.sol
@@ -1,0 +1,64 @@
+pragma solidity ^0.4.0;
+
+//Member election, must be approved by all current members.
+contract Member {
+
+    struct Ballot {
+        uint ticketNum;
+        mapping(address => uint) voters;
+    }
+
+    //enode => Ballot
+    mapping(string => Ballot) votes;
+
+    mapping(address => uint) members;
+
+    mapping(string => address) enodes;
+
+    uint memberNum;
+
+    event Vote(string enode,address voter);
+    event Register(string enode,address register);
+
+    //Funder build the contract.
+    function Member(string enode) public{
+        //register funder
+        members[msg.sender] = 1;
+        enodes[enode] = msg.sender;
+
+        //funder vote to himself
+        votes[enode].voters[msg.sender] = 1;
+        votes[enode].ticketNum++;
+
+        memberNum = 1;
+    }
+
+    //register to be member
+    function register(string enode) public {
+        if(members[enodes[enode]] == 1)
+            revert("the enode had registered.");
+        if(votes[enode].ticketNum <= 0)
+            revert("the enode is not voted.");
+        members[msg.sender] = 1;
+        enodes[enode] = msg.sender;
+        memberNum++;
+        emit Register(enode,msg.sender);
+    }
+
+    function vote(string enode) public {
+        if(votes[enode].voters[msg.sender] >= 1 )
+            revert("you had voted the enode.");
+        if(members[msg.sender] != 1)
+            revert("Can not vote from unregistered address.");
+        votes[enode].voters[msg.sender] = 1;
+        votes[enode].ticketNum++;
+        emit Vote(enode,msg.sender);
+    }
+
+    function isMember(string enode) constant public returns (bool result){
+        result = false;
+        if(votes[enode].ticketNum >= memberNum){
+            result = true;
+        }
+    }
+}


### PR DESCRIPTION
**合约说明：**
1. Member智能合约：当前会员选举新会员，当所有当前会员都vote新会员的enode，isMember（enode）返回true。
2. CCC监听Vote event，每次vote都调用isMember，判断该enode是否可成为会员。

**使用方法及新会员加入流程：**
1. 创始节点创建Member智能合约，new指令中传入创始节点的enode，进行自我投票和注册
2. 新申请会员将自己的enode分发给当前会员，当前会员分别调用智能合约的vote，为该enode投票
3. CCC判断当一个新会员得到全部会员投票，将该enode加入permission列表，下发给ethereum通信模块，当前以太坊网络接受该节点加入联盟链网络。
4. 新会员用自己的coinbase地址调用智能合约的register，成为注册会员，为后面申请者投票。